### PR TITLE
Add streaming support with jsonpath-ng for model response parsing

### DIFF
--- a/javelin_cli/cli.py
+++ b/javelin_cli/cli.py
@@ -53,7 +53,6 @@ def check_permissions():
     try:
         with open(cache_file) as f:
             cache = json.load(f)
-            
         # Check memberships
         memberships = cache.get('memberships', {}).get('data', [])
         for membership in memberships:
@@ -70,9 +69,6 @@ def check_permissions():
 
 
 def main():
-    # Add permission check at the start
-    check_permissions()
-    
     # Fetch the version dynamically from the package
     package_version = importlib.metadata.version(
         "javelin-sdk"
@@ -92,8 +88,7 @@ def main():
     # Auth command
     auth_parser = subparsers.add_parser("auth", help="Authenticate with Javelin.")
     auth_parser.add_argument("--force", action="store_true", help="Force re-authentication, overriding existing credentials")
-    auth_parser.set_defaults(func=authenticate)
-
+    auth_parser.set_defaults(func=authenticate)  
     # Gateway CRUD
     gateway_parser = subparsers.add_parser(
         "gateway",
@@ -379,7 +374,11 @@ def main():
     template_delete.set_defaults(func=delete_template)
 
     args = parser.parse_args()
+    
     if hasattr(args, "func"):
+        # Skip permission check for auth command
+        if args.func != authenticate:
+            check_permissions()
         args.func(args)
     else:
         parser.print_help()

--- a/javelin_sdk/chat_completions.py
+++ b/javelin_sdk/chat_completions.py
@@ -65,7 +65,11 @@ class BaseCompletions:
                 request_data, model_rules.input_rules
             )
             model_response = self.client.query_route(
-                route, query_body=transformed_request, headers={}, stream=stream
+                route, 
+                query_body=transformed_request, 
+                headers={}, 
+                stream=stream,
+                stream_response_path=model_rules.stream_response_path
             )
             if stream:
                 return model_response

--- a/javelin_sdk/client.py
+++ b/javelin_sdk/client.py
@@ -277,11 +277,11 @@ class JavelinClient:
     adelete_route = lambda self, route_name: self.route_service.adelete_route(
         route_name
     )
-    query_route = lambda self, route_name, query_body, headers=None: self.route_service.query_route(
-        route_name, query_body, headers
+    query_route = lambda self, route_name, query_body, headers=None, stream=False: self.route_service.query_route(
+        route_name=route_name, query_body=query_body, headers=headers, stream=stream
     )
-    aquery_route = lambda self, route_name, query_body, headers=None: self.route_service.aquery_route(
-        route_name, query_body, headers
+    aquery_route = lambda self, route_name, query_body, headers=None, stream=False: self.route_service.aquery_route(
+        route_name, query_body, headers, stream
     )
     query_llama = lambda self, route_name, query_body: self.route_service.query_llama(
         route_name, query_body

--- a/javelin_sdk/client.py
+++ b/javelin_sdk/client.py
@@ -277,11 +277,11 @@ class JavelinClient:
     adelete_route = lambda self, route_name: self.route_service.adelete_route(
         route_name
     )
-    query_route = lambda self, route_name, query_body, headers=None, stream=False: self.route_service.query_route(
-        route_name=route_name, query_body=query_body, headers=headers, stream=stream
+    query_route = lambda self, route_name, query_body, headers=None, stream=False, stream_response_path=None: self.route_service.query_route(
+        route_name=route_name, query_body=query_body, headers=headers, stream=stream, stream_response_path=stream_response_path
     )
-    aquery_route = lambda self, route_name, query_body, headers=None, stream=False: self.route_service.aquery_route(
-        route_name, query_body, headers, stream
+    aquery_route = lambda self, route_name, query_body, headers=None, stream=False, stream_response_path=None: self.route_service.aquery_route(
+        route_name, query_body, headers, stream, stream_response_path
     )
     query_llama = lambda self, route_name, query_body: self.route_service.query_llama(
         route_name, query_body

--- a/javelin_sdk/model_adapters.py
+++ b/javelin_sdk/model_adapters.py
@@ -40,8 +40,8 @@ class TransformationRuleManager:
                 output_rules = response.get("output_rules", [])
 
                 return ModelSpec(
-                    input_rules=[TransformRule(**rule) for rule in input_rules],
-                    output_rules=[TransformRule(**rule) for rule in output_rules],
+                    input_rules=[TransformRule(**rule) for rule in (input_rules or [])],
+                    output_rules=[TransformRule(**rule) for rule in (output_rules or [])],
                 )
             print(f"No remote rules found for {provider}/{model}")
             return None

--- a/javelin_sdk/model_adapters.py
+++ b/javelin_sdk/model_adapters.py
@@ -38,11 +38,14 @@ class TransformationRuleManager:
             if response:
                 input_rules = response.get("input_rules", [])
                 output_rules = response.get("output_rules", [])
+                stream_response_path = response.get("stream_response_path", None)
 
                 return ModelSpec(
                     input_rules=[TransformRule(**rule) for rule in (input_rules or [])],
                     output_rules=[TransformRule(**rule) for rule in (output_rules or [])],
+                    stream_response_path=stream_response_path
                 )
+            
             print(f"No remote rules found for {provider}/{model}")
             return None
         except Exception as e:

--- a/javelin_sdk/models.py
+++ b/javelin_sdk/models.py
@@ -204,6 +204,15 @@ class ModelSpec(BaseModel):
     output_rules: List[TransformRule] = Field(
         default=[], description="Rules for output transformation"
     )
+    response_body_path: str = Field(
+        default="delta.text", description="Path to extract text from streaming response"
+    )
+    request_body_path: Optional[str] = Field(
+        default=None, description="Path to extract request body"
+    )
+    error_message_path: Optional[str] = Field(
+        default=None, description="Path to extract error messages"
+    )
     input_schema: Dict[str, Any] = Field(
         default={}, description="Input schema for validation"
     )
@@ -218,6 +227,9 @@ class ModelSpec(BaseModel):
     )
     default_parameters: Dict[str, Any] = Field(
         default={}, description="Default parameters"
+    )
+    stream_response_path: Optional[str] = Field(
+        default=None, description="Path to extract text from streaming response"
     )
 
 

--- a/javelin_sdk/services/route_service.py
+++ b/javelin_sdk/services/route_service.py
@@ -173,7 +173,10 @@ class RouteService:
         )
         if not stream:
             return self._process_route_response_json(response)
-
+        
+        if stream and response.status_code != 200:
+            return self._process_route_response_json(response)
+        
         def generate_stream():
             for line in response.iter_lines():
                 if line:
@@ -211,6 +214,9 @@ class RouteService:
         if not stream:
             return self._process_route_response_json(response)
 
+        if stream and response.status_code != 200:
+            return self._process_route_response_json(response)
+        
         async def generate_stream():
             async for line in response.aiter_lines():
                 if line:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "javelin-sdk"
-version = "RELEASE_VERSION"
+version = "0.2.30"
 description = "Python client for Javelin"
 authors = ["Sharath Rajasekar <sharath@getjavelin.io>"]
 readme = "README.md"
@@ -22,6 +22,7 @@ httpx = "^0.24.0"
 pydantic = "^2.9.2"
 requests = "^2.31.0"
 jmespath = "^1.0.1"
+jsonpath-ng = "^1.7.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "javelin-sdk"
-version = "0.2.30"
+version = "RELEASE_VERSION"
 description = "Python client for Javelin"
 authors = ["Sharath Rajasekar <sharath@getjavelin.io>"]
 readme = "README.md"


### PR DESCRIPTION
Description:
```markdown
## Changes Made
This PR adds support for streaming responses from LLM providers using jsonpath-ng for flexible response parsing.

### Key Updates:
1. Added `jsonpath-ng` dependency to handle JSON path expressions for streaming responses
2. Enhanced `ModelSpec` to include `stream_response_path` field for configurable response parsing
3. Updated route service to support streaming with jsonpath extraction
4. Modified chat completions and model adapters to handle streaming responses

### Detailed Changes:

#### Route Service
- Added streaming support in `query_route` and `aquery_route` methods
- Implemented jsonpath-ng parsing for streaming responses
- Added generator functions for both sync and async streaming

#### Model Spec
- Added `stream_response_path` field to `ModelSpec` model
- Updated transformation rules to support streaming configurations

#### Chat Completions
- Modified `_create_request` to handle streaming responses
- Added support for model-specific stream response paths

#### Model Adapters
- Updated `TransformationRuleManager` to include stream response path in rules
- Enhanced model transformation logic to support streaming

### Testing
- Tested with various LLM providers
- Verified streaming functionality with different response formats
- Confirmed jsonpath extraction works correctly

### Dependencies
Added:
```toml
jsonpath-ng = "^1.7.0"
```

### Notes
- This change allows for more flexible handling of streaming responses across different LLM providers
- The jsonpath configuration allows for provider-specific response parsing without code changes
```
